### PR TITLE
add support for global event hooks, closes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ emit(state.events.clicks.increment, 1)
 emit('clicks:increment', 1)
 ```
 
+### Global Events
+
+You can listen for any of Choo's global events (`DOMContentLoaded`, `DOMTitleChange`,
+`navigate`, `popState`, `pushState`, `render`, `replaceState`) by adding an event
+with the appropriate name to the `events` object:
+
+```js
+createStore({
+  storeName: 'history',
+  initialState: { navigations: 0 },
+  events: {
+    navigate: ({ store, emitter }) => {
+      store.navigations++
+      emitter.emit('render')
+    }
+  }
+})
+```
+
+> Note: global events are not added to `state.events[storeName]` and do not have
+an action function associated with them since they are not namespaced events.
+
 ### `reset` event
 
 A `reset` event (e.g. `storeName:reset`) is added by default.

--- a/index.js
+++ b/index.js
@@ -1,3 +1,13 @@
+var globals = [
+  'DOMContentLoaded',
+  'DOMTitleChange',
+  'navigate',
+  'popState',
+  'pushState',
+  'render',
+  'replaceState'
+]
+
 function createStore (opts) {
   var { storeName, initialState, events } = opts || {}
 
@@ -22,18 +32,21 @@ function createStore (opts) {
     }
 
     Object.keys(events).forEach(event => {
-      var eventName = `${storeName}:${event}`
+      var eventName = globals.includes(event) ? event : `${storeName}:${event}`
 
       // attach events to emitter
       emitter.on(eventName, data => {
         events[event]({ data, store: state[storeName], emitter, state, app })
       })
 
-      // add event names to state.events
-      state.events[storeName][event] = eventName
+      // don't create namespaced event hooks for global events
+      if (!globals.includes(event)) {
+        // add event names to state.events
+        state.events[storeName][event] = eventName
 
-      // add action method
-      props.actions[event] = data => emitter.emit(eventName, data)
+        // add action method
+        props.actions[event] = data => emitter.emit(eventName, data)
+      }
     })
   }
 

--- a/test.js
+++ b/test.js
@@ -19,7 +19,7 @@ test('storeName', t => {
 })
 
 test('integration', t => {
-  var app, objStore, arrStore, resetStore
+  var app, objStore, arrStore, resetStore, globalStore
 
   t.test('instantiation', t => {
     t.doesNotThrow(() => {
@@ -58,6 +58,18 @@ test('integration', t => {
       })
     }, 'create reset store')
 
+    t.doesNotThrow(() => {
+      globalStore = createStore({
+        storeName: 'global',
+        initialState: { navigations: 0 },
+        events: {
+          navigate: function ({ store }) {
+            store.navigations++
+          }
+        }
+      })
+    }, 'create global (navigation) store')
+
     t.end()
   })
 
@@ -67,6 +79,7 @@ test('integration', t => {
       app.use(objStore)
       app.use(arrStore)
       app.use(resetStore)
+      app.use(globalStore)
       app.route('/', (state, emit) => html`<body></body>`)
       app.toString('/')
     }, 'stores register')
@@ -78,7 +91,7 @@ test('integration', t => {
     t.equals(app.state.obj.a, 1, 'objStore state is good')
     t.equals(app.state.arr[0], 1, 'arrStore state is good')
     t.equals(app.state.reset.a, 3, 'resetStore state is good')
-
+    t.equals(app.state.global.navigations, 0, 'globalStore state is good')
     t.end()
   })
 
@@ -88,6 +101,16 @@ test('integration', t => {
 
     t.equals(app.state.obj.a, 2, 'arrStore state updated')
     t.equals(app.state.arr[0], 2, 'arrStore state updated')
+
+    t.end()
+  })
+
+  t.test('global navigation', t => {
+    t.notOk(globalStore.actions.navigate, 'global event not namespaced')
+
+    app.emit(app.state.events.NAVIGATE)
+
+    t.equals(app.state.global.navigations, 1, 'globalStore state updated')
 
     t.end()
   })


### PR DESCRIPTION
Per our conversation, this PR adds support for defining event listeners for global events in a `choo-store` event object.

Global events do not get added to `state.events[storeName]` (since they are already reserved under `state.events`) and do not get added to the actions object (since they are not namespaced events).

Will update the README in a followup commit.